### PR TITLE
Support named re-exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,30 @@ function isExportOnly(program) {
   return program.body.length === 1 && program.body[0].type === 'ExportNamedDeclaration';
 }
 
+function isRenamedExport(specifier) {
+  return specifier.local.name !== specifier.exported.name;
+}
+
 // Check if the given export statement is a re-export
 function exportIsReExport(exportNamedDeclaration) {
-  return !!exportNamedDeclaration.source && !!exportNamedDeclaration.specifiers.length;
+  if (
+    !(
+      !!exportNamedDeclaration.source &&
+      !!exportNamedDeclaration.specifiers.length
+    )
+  ) {
+    return false;
+  }
+
+  for (let i = 0; i < exportNamedDeclaration.specifiers.length; i++) {
+    let specifier = exportNamedDeclaration.specifiers[i];
+
+    if (isRenamedExport(specifier)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 // Get the source of a re-export for the given Program

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "loader.js": "^4.4.0",
     "nyc": "^10.3.0",
     "qunit-eslint": "^1.0.0",
-    "qunitjs": "^2.3.2"
+    "qunitjs": "^2.4.1"
   }
 }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -68,4 +68,9 @@ QUnit.module('compact-reexports', function() {
     const result = transform('const a = "boo"; export { default } from "foo";');
     assert.equal(result.indexOf('define.alias'), -1);
   });
+
+  QUnit.test('does not transform named re-exports', function (assert) {
+    const result = transform('export { foo as bar } from "foo";');
+    assert.equal(result.indexOf('define.alias'), -1)
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,7 +843,7 @@ find-up@^1.0.0, find-up@^1.1.2:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-findup-sync@^0.4.3:
+findup-sync@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
   dependencies:
@@ -1818,15 +1818,16 @@ qunit-eslint@^1.0.0:
     eslint "^3.19.0"
     walk-sync "^0.3.1"
 
-qunitjs@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.3.2.tgz#938ce24250aa3717b90b47598f1429b10343d85a"
+qunitjs@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.1.tgz#88aba055a9e2ec3dbebfaad02471b2cb002c530b"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"
     exists-stat "1.0.0"
-    findup-sync "^0.4.3"
+    findup-sync "0.4.3"
     js-reporters "1.2.0"
+    resolve "1.3.2"
     walk-sync "0.3.1"
 
 randomatic@^1.1.3:
@@ -2005,6 +2006,12 @@ resolve-from@^1.0.0:
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
+resolve@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  dependencies:
+    path-parse "^1.0.5"
 
 resolve@^1.1.6:
   version "1.3.3"


### PR DESCRIPTION
`export { foo as bar } from "./foo"` should not be replaced with a compact
re-export.

Fixes https://github.com/ember-engines/babel-plugin-compact-reexports/issues/5
Also bumps qunitjs to run on modern node versions