### PR TITLE
Add support for ExportAllDeclaration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,10 @@ function isReExportOnly(program) {
 
 // Check if a given Program is only an export statement
 function isExportOnly(program) {
-  return program.body.length === 1 && program.body[0].type === 'ExportNamedDeclaration';
+  return program.body.length === 1 && (
+    program.body[0].type === 'ExportNamedDeclaration' ||
+    program.body[0].type === 'ExportAllDeclaration'
+  );
 }
 
 function isRenamedExport(specifier) {
@@ -18,6 +21,10 @@ function isRenamedExport(specifier) {
 
 // Check if the given export statement is a re-export
 function exportIsReExport(exportNamedDeclaration) {
+  if (exportNamedDeclaration.type === 'ExportAllDeclaration') {
+    return true;
+  }
+
   if (
     !(
       !!exportNamedDeclaration.source &&

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "test": "nyc qunit tests/*-test.js"
+    "test": "nyc qunit tests/*-test.js",
+    "test:debug": "node debug ./node_modules/.bin/qunit tests/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -18,59 +18,104 @@ QUnit.module('compact-reexports', function() {
     return babel.transform(code, options).code.trim();
   }
 
-  QUnit.test('correctly transforms simple re-export', function(assert) {
-    const result = transform('export { default } from "foo";');
-    assert.equal(result, 'define.alias("foo", "bar");');
-  });
-
-  QUnit.test('correctly transforms simple re-export of nested path', function(assert) {
-    const result = transform('export { default } from "some/path/to/foo";', undefined, 'other/path/to/bar');
-    assert.equal(result, 'define.alias("some/path/to/foo", "other/path/to/bar");');
-  });
-
-  QUnit.test('correctly transforms simple re-export with loose', function(assert) {
-    const result = transform('export { default } from "foo";', {
-      loose: true
+  QUnit.module('modern export *', function() {
+    QUnit.test('correctly transforms simple re-export', function(assert) {
+      const result = transform('export * from "foo";');
+      assert.equal(result, 'define.alias("foo", "bar");');
     });
-    assert.equal(result, 'define.alias("foo", "bar");');
-  });
 
-  QUnit.test('correctly transforms simple re-export with strict', function(assert) {
-    const result = transform('export { default } from "foo";', {
-      strict: true
+    QUnit.test('correctly transforms simple re-export of nested path', function(assert) {
+      const result = transform('export * from "some/path/to/foo";', undefined, 'other/path/to/bar');
+      assert.equal(result, 'define.alias("some/path/to/foo", "other/path/to/bar");');
     });
-    assert.equal(result, 'define.alias("foo", "bar");');
-  });
 
-  QUnit.test('correctly transforms simple re-export with noInterop', function(assert) {
-    const result = transform('export { default } from "foo";', {
-      noInterop: true
+    QUnit.test('correctly transforms simple re-export with loose', function(assert) {
+      const result = transform('export * from "foo";', {
+        loose: true
+      });
+      assert.equal(result, 'define.alias("foo", "bar");');
     });
-    assert.equal(result, 'define.alias("foo", "bar");');
+
+    QUnit.test('correctly transforms simple re-export with strict', function(assert) {
+      const result = transform('export * from "foo";', {
+        strict: true
+      });
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
+
+    QUnit.test('correctly transforms simple re-export with noInterop', function(assert) {
+      const result = transform('export * from "foo";', {
+        noInterop: true
+      });
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
+
+    QUnit.test('correctly transforms re-export using relative paths', function(assert) {
+      const result = transform('export * from "../components/foo-bar";', undefined, 'app/components/bar-foo');
+      assert.equal(result, 'define.alias("app/components/foo-bar", "app/components/bar-foo");');
+    });
+
+    QUnit.test('does not transform re-exports with other code', function(assert) {
+      const result = transform('const a = "boo"; export * from "foo";');
+      assert.equal(result.indexOf('define.alias'), -1);
+    });
   });
 
-  QUnit.test('correctly transforms re-export using relative paths', function(assert) {
-    const result = transform('export { default } from "../components/foo-bar";', undefined, 'app/components/bar-foo');
-    assert.equal(result, 'define.alias("app/components/foo-bar", "app/components/bar-foo");');
-  });
+  QUnit.module('legacy/compat export { default }', function() {
+    QUnit.test('correctly transforms simple re-export', function(assert) {
+      const result = transform('export { default } from "foo";');
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
 
-  QUnit.test('correctly transforms re-export of module with more than one export', function(assert) {
-    const result = transform('export { default, helper } from "foo";');
-    assert.equal(result, 'define.alias("foo", "bar");');
-  });
+    QUnit.test('correctly transforms simple re-export of nested path', function(assert) {
+      const result = transform('export { default } from "some/path/to/foo";', undefined, 'other/path/to/bar');
+      assert.equal(result, 'define.alias("some/path/to/foo", "other/path/to/bar");');
+    });
 
-  QUnit.test('does not transform indirect re-export', function(assert) {
-    const result = transform('import Foo from "foo"; export default Foo;');
-    assert.equal(result.indexOf('define.alias'), -1);
-  });
+    QUnit.test('correctly transforms simple re-export with loose', function(assert) {
+      const result = transform('export { default } from "foo";', {
+        loose: true
+      });
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
 
-  QUnit.test('does not transform re-exports with other code', function(assert) {
-    const result = transform('const a = "boo"; export { default } from "foo";');
-    assert.equal(result.indexOf('define.alias'), -1);
-  });
+    QUnit.test('correctly transforms simple re-export with strict', function(assert) {
+      const result = transform('export { default } from "foo";', {
+        strict: true
+      });
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
 
-  QUnit.test('does not transform named re-exports', function (assert) {
-    const result = transform('export { foo as bar } from "foo";');
-    assert.equal(result.indexOf('define.alias'), -1)
+    QUnit.test('correctly transforms simple re-export with noInterop', function(assert) {
+      const result = transform('export { default } from "foo";', {
+        noInterop: true
+      });
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
+
+    QUnit.test('correctly transforms re-export using relative paths', function(assert) {
+      const result = transform('export { default } from "../components/foo-bar";', undefined, 'app/components/bar-foo');
+      assert.equal(result, 'define.alias("app/components/foo-bar", "app/components/bar-foo");');
+    });
+
+    QUnit.test('correctly transforms re-export of module with more than one export', function(assert) {
+      const result = transform('export { default, helper } from "foo";');
+      assert.equal(result, 'define.alias("foo", "bar");');
+    });
+
+    QUnit.test('does not transform indirect re-export', function(assert) {
+      const result = transform('import Foo from "foo"; export default Foo;');
+      assert.equal(result.indexOf('define.alias'), -1);
+    });
+
+    QUnit.test('does not transform re-exports with other code', function(assert) {
+      const result = transform('const a = "boo"; export { default } from "foo";');
+      assert.equal(result.indexOf('define.alias'), -1);
+    });
+
+    QUnit.test('does not transform named re-exports', function (assert) {
+      const result = transform('export { foo as bar } from "foo";');
+      assert.equal(result.indexOf('define.alias'), -1)
+    });
   });
 });


### PR DESCRIPTION
more context: https://github.com/ember-engines/babel-plugin-compact-reexports/issues/7

but TL;DR this adds support for:

```
export * from 'foo';
```

Allowing it to be compacted to:

```
define.alias(<name>, 'foo');
```