### PR TITLE
Resolve the source file name while constructing define alias

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { moduleResolve } = require('amd-name-resolver');
 
 // Check if a given Program is only a re-export statement
 function isReExportOnly(program) {
@@ -87,7 +88,8 @@ function CompactReexports(babel) {
           if (state.reexport) {
             const source = state.reexport.source;
             const alias = this.getModuleName();
-            const newProgram = t.program( [ constructDefineAlias(t, source, alias) ] );
+            let resolvedSource = moduleResolve(source, alias)
+            const newProgram = t.program( [ constructDefineAlias(t, resolvedSource, alias) ] );
 
             path.replaceWith(newProgram);
             path.stop();


### PR DESCRIPTION
With Babel 7, compact reexports transformation happen before module name is resolved by babel-plugin-module-resolver. Hence resolving the source name in this plugin itself will avoid any name resolution error. 